### PR TITLE
Various cleanup on the branch.

### DIFF
--- a/ravenframework/Optimizers/GeneticAlgorithm.py
+++ b/ravenframework/Optimizers/GeneticAlgorithm.py
@@ -788,7 +788,15 @@ class GeneticAlgorithm(RavenSampled):
 
     offSprings = datasetToDataArray(rlz, list(self.toBeSampled))
 
-    g, objectiveVal, offSpringFitness = constraintHandling(self, info, rlz, offSprings, multiObjective=self._isMultiObjective)
+    # Handle objective values differently for single and multi-objective cases
+    if self._isMultiObjective:
+        objectiveVal = []
+        for i in range(len(self._objectiveVar)):
+            objectiveVal.append(list(np.atleast_1d(rlz[self._objectiveVar[i]].data)))
+    else:
+        objectiveVal = list(np.atleast_1d(rlz[self._objectiveVar[0]].data))
+
+    g, offSpringFitness = constraintHandling(self, info, rlz, offSprings, objectiveVal, multiObjective=self._isMultiObjective)
 
 
     # 0.2@ n-1: Survivor selection(rlz): Update population container given obtained children

--- a/ravenframework/Optimizers/GeneticAlgorithm.py
+++ b/ravenframework/Optimizers/GeneticAlgorithm.py
@@ -792,8 +792,7 @@ class GeneticAlgorithm(RavenSampled):
 
     # 0.2@ n-1: Survivor selection(rlz): Update population container given obtained children
     if self._activeTraj:
-      survivorSelectionFuncs: dict = {1: survivorSelectionProcess.singleObjSurvivorSelect, 2: survivorSelectionProcess.multiObjSurvivorSelect}
-      survivorSelection = survivorSelectionFuncs.get(objInd, survivorSelectionProcess.singleObjSurvivorSelect)
+      survivorSelection =  survivorSelectionProcess.multiObjSurvivorSelect if objInd == 2 else  survivorSelectionProcess.singleObjSurvivorSelect
       survivorSelection(self, info, rlz, traj, offSprings, offSpringFitness, objectiveVal, g)
 
       # 1 @ n: Parent selection from population

--- a/ravenframework/Optimizers/GeneticAlgorithm.py
+++ b/ravenframework/Optimizers/GeneticAlgorithm.py
@@ -796,8 +796,22 @@ class GeneticAlgorithm(RavenSampled):
     else:
         objectiveVal = list(np.atleast_1d(rlz[self._objectiveVar[0]].data))
 
-    g, offSpringFitness = constraintHandling(self, info, rlz, offSprings, objectiveVal, multiObjective=self._isMultiObjective)
+    g = constraintHandling(self, info, rlz, offSprings, objectiveVal, multiObjective=self._isMultiObjective)
 
+    # Compute fitness for the offspring
+    offSpringFitness = self._fitnessInstance(rlz,
+                                             objVar=self._objectiveVar,
+                                             a=self._objCoeff,
+                                             b=self._penaltyCoeff,
+                                             penalty=None,
+                                             constraintFunction=g,
+                                             constraintNum=self._numOfConst,
+                                             type=self._minMax)
+
+    # Single-objective post-processing (if needed)
+    if not self._isMultiObjective:
+        self._collectOptPoint(rlz, offSpringFitness, objectiveVal, g)
+        self._resolveNewGeneration(traj, rlz, objectiveVal, offSpringFitness, g, info)
 
     # 0.2@ n-1: Survivor selection(rlz): Update population container given obtained children
     if self._activeTraj:

--- a/ravenframework/Optimizers/GeneticAlgorithm.py
+++ b/ravenframework/Optimizers/GeneticAlgorithm.py
@@ -786,7 +786,9 @@ class GeneticAlgorithm(RavenSampled):
     # 0 @ n-1: Survivor Selection from previous iteration (children+parents merging from previous generation)
     # 0.1 @ n-1: fitnessCalculation(rlz): Perform fitness calculation for newly obtained children (rlz)
 
-    g, objectiveVal, offSprings, offSpringFitness = constraintHandling(self, info, rlz, multiObjective=self._isMultiObjective)
+    offSprings = datasetToDataArray(rlz, list(self.toBeSampled))
+
+    g, objectiveVal, offSpringFitness = constraintHandling(self, info, rlz, offSprings, multiObjective=self._isMultiObjective)
 
 
     # 0.2@ n-1: Survivor selection(rlz): Update population container given obtained children

--- a/ravenframework/Optimizers/GeneticAlgorithm.py
+++ b/ravenframework/Optimizers/GeneticAlgorithm.py
@@ -786,13 +786,12 @@ class GeneticAlgorithm(RavenSampled):
     # 0 @ n-1: Survivor Selection from previous iteration (children+parents merging from previous generation)
     # 0.1 @ n-1: fitnessCalculation(rlz): Perform fitness calculation for newly obtained children (rlz)
 
-    objInd = int(len(self._objectiveVar)>1) + 1
     g, objectiveVal, offSprings, offSpringFitness = constraintHandling(self, info, rlz, multiObjective=self._isMultiObjective)
 
 
     # 0.2@ n-1: Survivor selection(rlz): Update population container given obtained children
     if self._activeTraj:
-      survivorSelection =  survivorSelectionProcess.multiObjSurvivorSelect if objInd == 2 else  survivorSelectionProcess.singleObjSurvivorSelect
+      survivorSelection =  survivorSelectionProcess.multiObjSurvivorSelect if len(self._objectiveVar) > 1 else  survivorSelectionProcess.singleObjSurvivorSelect
       survivorSelection(self, info, rlz, traj, offSprings, offSpringFitness, objectiveVal, g)
 
       # 1 @ n: Parent selection from population

--- a/ravenframework/Optimizers/GeneticAlgorithm.py
+++ b/ravenframework/Optimizers/GeneticAlgorithm.py
@@ -815,8 +815,34 @@ class GeneticAlgorithm(RavenSampled):
 
     # 0.2@ n-1: Survivor selection(rlz): Update population container given obtained children
     if self._activeTraj:
-      survivorSelection =  survivorSelectionProcess.multiObjSurvivorSelect if len(self._objectiveVar) > 1 else  survivorSelectionProcess.singleObjSurvivorSelect
+      survivorSelection =  survivorSelectionProcess.multiObjSurvivorSelect if self._isMultiObjective else  survivorSelectionProcess.singleObjSurvivorSelect
       survivorSelection(self, info, rlz, traj, offSprings, offSpringFitness, objectiveVal, g)
+      if self._isMultiObjective:
+        if self.counter <= 1:
+          # offspringObjsVals for Rank and CD calculation
+          fitVal = datasetToDataArray(self.fitness, self._objectiveVar).data
+          offspringFitVals = fitVal.tolist()
+          offSpringRank = frontUtils.rankNonDominatedFrontiers(np.array(offspringFitVals), isFitness=True)
+          self.rank     = xr.DataArray(offSpringRank,
+                                       dims=['rank'],
+                                       coords={'rank': np.arange(np.shape(offSpringRank)[0])})
+          offSpringCD           = frontUtils.crowdingDistance(rank=offSpringRank,
+                                                              popSize=len(offSpringRank),
+                                                              fitness=np.array(offspringFitVals))
+          self.crowdingDistance = xr.DataArray(offSpringCD,
+                                               dims=['CrowdingDistance'],
+                                               coords={'CrowdingDistance': np.arange(np.shape(offSpringCD)[0])})
+          self.objectiveVal = []
+          for i in range(len(self._objectiveVar)):
+            self.objectiveVal.append(list(np.atleast_1d(rlz[self._objectiveVar[i]].data)))
+        self._collectOptPointMulti(self.population,
+                                   self.rank,
+                                   self.crowdingDistance,
+                                   self.objectiveVal,
+                                   self.fitness,
+                                   self.constraintsV)
+        self._resolveNewGenerationMulti(traj, rlz, info)
+
 
       # 1 @ n: Parent selection from population
       # Pair parents together by indexes

--- a/ravenframework/Optimizers/RavenSampled.py
+++ b/ravenframework/Optimizers/RavenSampled.py
@@ -303,7 +303,7 @@ class RavenSampled(Optimizer):
     # so get the correct-signed value into the realization
 
     if 'max' in self._minMax:
-      if not self._canHandleMultiObjective and len(self._objectiveVar) == 1:
+      if not self._isMultiObjective:
         rlz[self._objectiveVar[0]] *= -1
       elif type(self._objectiveVar) == list:
         for i in range(len(self._objectiveVar)):
@@ -422,7 +422,7 @@ class RavenSampled(Optimizer):
         self.raiseAnError(RuntimeError, f'There is no optimization history for traj {traj}! ' +
                           'Perhaps the Model failed?')
 
-      if len(self._objectiveVar) == 1:
+      if not self._isMultiObjective:
         opt = self._optPointHistory[traj][-1][0]
         val = opt[self._objectiveVar]
         self.raiseADebug(statusTemplate.format(status='active', traj=traj, val=s * val))

--- a/ravenframework/Optimizers/constraintHandling/constraintHandling.py
+++ b/ravenframework/Optimizers/constraintHandling/constraintHandling.py
@@ -22,7 +22,7 @@ import xarray as xr
 import numpy as np
 from ..GeneticAlgorithm import datasetToDataArray
 
-def constraintHandling(self, info, rlz, multiObjective=False):
+def constraintHandling(self, info, rlz, offSprings, multiObjective=False):
     """
     This function handles the constraints for both single and multi-objective optimization.
     @ In, info, dict, dictionary containing information about the run
@@ -31,7 +31,6 @@ def constraintHandling(self, info, rlz, multiObjective=False):
     @ Out, None
     """
     traj = info['traj']
-    offSprings = datasetToDataArray(rlz, list(self.toBeSampled))
 
     # Handle objective values differently for single and multi-objective cases
     if multiObjective:
@@ -95,4 +94,4 @@ def constraintHandling(self, info, rlz, multiObjective=False):
         self._collectOptPoint(rlz, offSpringFitness, objectiveVal, g)
         self._resolveNewGeneration(traj, rlz, objectiveVal, offSpringFitness, g, info)
 
-    return g, objectiveVal, offSprings, offSpringFitness
+    return g, objectiveVal, offSpringFitness

--- a/ravenframework/Optimizers/constraintHandling/constraintHandling.py
+++ b/ravenframework/Optimizers/constraintHandling/constraintHandling.py
@@ -71,19 +71,4 @@ def constraintHandling(self, info, rlz, offSprings, objectiveVal, multiObjective
             else:
                 g.data[index, constIndex] = self._handleImplicitConstraints(newOpt, opt, constraint)
 
-    # Compute fitness for the offspring
-    offSpringFitness = self._fitnessInstance(rlz,
-                                             objVar=self._objectiveVar,
-                                             a=self._objCoeff,
-                                             b=self._penaltyCoeff,
-                                             penalty=None,
-                                             constraintFunction=g,
-                                             constraintNum=self._numOfConst,
-                                             type=self._minMax)
-
-    # Single-objective post-processing (if needed)
-    if not multiObjective:
-        self._collectOptPoint(rlz, offSpringFitness, objectiveVal, g)
-        self._resolveNewGeneration(traj, rlz, objectiveVal, offSpringFitness, g, info)
-
-    return g, offSpringFitness
+    return g

--- a/ravenframework/Optimizers/constraintHandling/constraintHandling.py
+++ b/ravenframework/Optimizers/constraintHandling/constraintHandling.py
@@ -22,7 +22,7 @@ import xarray as xr
 import numpy as np
 from ..GeneticAlgorithm import datasetToDataArray
 
-def constraintHandling(self, info, rlz, offSprings, multiObjective=False):
+def constraintHandling(self, info, rlz, offSprings, objectiveVal, multiObjective=False):
     """
     This function handles the constraints for both single and multi-objective optimization.
     @ In, info, dict, dictionary containing information about the run
@@ -31,14 +31,6 @@ def constraintHandling(self, info, rlz, offSprings, multiObjective=False):
     @ Out, None
     """
     traj = info['traj']
-
-    # Handle objective values differently for single and multi-objective cases
-    if multiObjective:
-        objectiveVal = []
-        for i in range(len(self._objectiveVar)):
-            objectiveVal.append(list(np.atleast_1d(rlz[self._objectiveVar[i]].data)))
-    else:
-        objectiveVal = list(np.atleast_1d(rlz[self._objectiveVar[0]].data))
 
     # Collect parameters for constraint functions (excluding default params)
     constraintData = {}
@@ -94,4 +86,4 @@ def constraintHandling(self, info, rlz, offSprings, multiObjective=False):
         self._collectOptPoint(rlz, offSpringFitness, objectiveVal, g)
         self._resolveNewGeneration(traj, rlz, objectiveVal, offSpringFitness, g, info)
 
-    return g, objectiveVal, offSpringFitness
+    return g, offSpringFitness

--- a/ravenframework/Optimizers/survivorSelection/survivorSelection.py
+++ b/ravenframework/Optimizers/survivorSelection/survivorSelection.py
@@ -83,26 +83,3 @@ def multiObjSurvivorSelect(self, info, rlz, traj, offSprings, offSpringFitness, 
     self.population = offSprings
     self.fitness = offSpringFitness
     self.constraintsV = g
-    # offspringObjsVals for Rank and CD calculation
-    fitVal = datasetToDataArray(self.fitness, self._objectiveVar).data
-    offspringFitVals = fitVal.tolist()
-    offSpringRank = frontUtils.rankNonDominatedFrontiers(np.array(offspringFitVals), isFitness=True)
-    self.rank     = xr.DataArray(offSpringRank,
-                                 dims=['rank'],
-                                 coords={'rank': np.arange(np.shape(offSpringRank)[0])})
-    offSpringCD           = frontUtils.crowdingDistance(rank=offSpringRank,
-                                                        popSize=len(offSpringRank),
-                                                        fitness=np.array(offspringFitVals))
-    self.crowdingDistance = xr.DataArray(offSpringCD,
-                                         dims=['CrowdingDistance'],
-                                         coords={'CrowdingDistance': np.arange(np.shape(offSpringCD)[0])})
-    self.objectiveVal = []
-    for i in range(len(self._objectiveVar)):
-      self.objectiveVal.append(list(np.atleast_1d(rlz[self._objectiveVar[i]].data)))
-  self._collectOptPointMulti(self.population,
-                             self.rank,
-                             self.crowdingDistance,
-                             self.objectiveVal,
-                             self.fitness,
-                             self.constraintsV)
-  self._resolveNewGenerationMulti(traj, rlz, info)

--- a/ravenframework/utils/plotUtils.py
+++ b/ravenframework/utils/plotUtils.py
@@ -32,11 +32,13 @@ def errorFill(x, y, yerr, color=None, alphaFill=0.3, ax=None, logScale=False):
     @ Out, None
   """
   ax = ax if ax is not None else plt.gca()
-  if np.isscalar(yerr) or len(yerr) == len(y):
+  if np.isscalar(yerr) or (len(yerr) == len(y) and np.ndim(yerr) == 1):
     ymin = y - yerr
     ymax = y + yerr
   elif len(yerr) == 2:
     ymin, ymax = yerr
+  else:
+    print(f"Unhandled {yerr=} with {y=}")
   ax.plot(x, y, color=color)
   ax.fill_between(x, ymax, ymin, color=color, alpha=alphaFill)
   if logScale:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

